### PR TITLE
Simplify user-not-found translations

### DIFF
--- a/custom_components/ha_guest_mode/services.py
+++ b/custom_components/ha_guest_mode/services.py
@@ -28,7 +28,18 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
             break
     
     if user_id is None:
-        raise vol.Invalid(translations.get("component.ha_guest_mode.config.error.user_not_found").format(username))
+        user_not_found_template = translations.get(
+            "component.ha_guest_mode.config.error.user_not_found"
+        )
+
+        if isinstance(user_not_found_template, str):
+            user_not_found_message = user_not_found_template
+        else:
+            user_not_found_message = "User not found"
+
+        user_not_found_message = f"{user_not_found_message}: {username}"
+
+        raise vol.Invalid(user_not_found_message)
 
     if expiration_duration is not None and expiration_date is not None:
         raise vol.Invalid(translations.get("component.ha_guest_mode.config.error.expiration_exclusive"))

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "Benutzer {0} nicht gefunden",
+            "user_not_found": "Benutzer nicht gefunden",
             "expiration_exclusive": "Geben Sie nur eine von Ablaufdauer oder Ablaufdatum an"
         }
     },

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "User {0} not found",
+            "user_not_found": "User not found",
             "expiration_exclusive": "Specify only one of expiration_duration or expiration_date"
         }
     },

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "Usuario {0} no encontrado",
+            "user_not_found": "Usuario no encontrado",
             "expiration_exclusive": "Especifique solo una de duración de expiración o fecha de expiración"
         }
     },

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "Utilisateur {0} non trouvé",
+            "user_not_found": "Utilisateur introuvable",
             "expiration_exclusive": "Spécifiez uniquement une durée d'expiration ou une date d'expiration"
         }
     },

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "Utente {0} non trovato",
+            "user_not_found": "Utente non trovato",
             "expiration_exclusive": "Specifica solo una tra durata di scadenza o data di scadenza"
         }
     },

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -12,7 +12,7 @@
             }
         },
         "error": {
-            "user_not_found": "Gebruiker {0} niet gevonden",
+            "user_not_found": "Gebruiker niet gevonden",
             "expiration_exclusive": "Geef slechts één van vervaltijd of vervaldatum op"
         }
     },


### PR DESCRIPTION
## Summary
- remove the username placeholder from the user-not-found error message in each locale to satisfy Hassfest validation
- update the create_token service to use the simplified translation and append the looked-up username in code

## Testing
- python3 -m compileall custom_components/ha_guest_mode

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db80ac89083319c9d0784f33b00ca)