### PR TITLE
feat: add Mac shortcut for create token

### DIFF
--- a/custom_components/ha_guest_mode/manifest.json
+++ b/custom_components/ha_guest_mode/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/Darkdragon14/ha-guest-mode/issues",
     "requirements": ["qrcode", "Pillow"],
-    "version": "v1.23.0"
+    "version": "v1.23.1"
 }

--- a/custom_components/ha_guest_mode/www/ha-guest-mode.js
+++ b/custom_components/ha_guest_mode/www/ha-guest-mode.js
@@ -655,6 +655,15 @@ class GuestModePanel extends LitElement {
     this.modalAlert = '';
   }
 
+  isMacOS() {
+    const platform = navigator.userAgentData?.platform || navigator.platform || '';
+    return platform.toLowerCase().includes('mac');
+  }
+
+  getCreateTokenShortcutLabel() {
+    return this.isMacOS() ? 'Cmd+Option+N' : 'Alt+Shift+N';
+  }
+
   handleGlobalKeydown(e) {
     if (e.defaultPrevented || e.repeat) {
       return;
@@ -674,7 +683,25 @@ class GuestModePanel extends LitElement {
       return;
     }
 
-    if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && e.key?.toLowerCase() === 'n') {
+    const isMac = this.isMacOS();
+
+    const isMacShortcut =
+      isMac &&
+      e.metaKey &&
+      e.altKey &&
+      !e.ctrlKey &&
+      !e.shiftKey &&
+      e.key?.toLowerCase() === 'n';
+
+    const isNonMacShortcut =
+      !isMac &&
+      e.altKey &&
+      e.shiftKey &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      e.key?.toLowerCase() === 'n';
+
+    if (isMacShortcut || isNonMacShortcut) {
       e.preventDefault();
       if (!this.isCreateDialogOpen) {
         this.openCreateDialog();
@@ -932,7 +959,7 @@ class GuestModePanel extends LitElement {
             <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" id="actions" role="toolbar">
               <mwc-icon-button
                 class="header-create-button"
-                title=${`${this.translate("create_token") || "Create token"} (Alt+Shift+N)`}
+                title=${`${this.translate("create_token") || "Create token"} (${this.getCreateTokenShortcutLabel()})`}
                 aria-label=${this.translate("create_token") || "Create token"}
                 @click=${this.openCreateDialog}
               >


### PR DESCRIPTION
## Summary
- Add OS-aware keyboard shortcut handling for token creation in the guest mode panel.
- Use `Cmd+Option+N` on macOS and keep `Alt+Shift+N` on non-macOS platforms.
- Update the create-token tooltip to display the shortcut for the current OS and bump manifest version to `v1.23.1`.