### PR TITLE
feat: add token creation defaults for user and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To install Guest Mode using [HACS](https://hacs.xyz/):
 |**Path for Admin UI**|Custom URL path for accessing the admin interface|No|`/guest-mode`|
 |**Login Path**|Custom URL path for guest to access the login page|No|`/guest-mode/login`|
 |**Copy link directly (skips sharing)**|If checked, clicking the share button will copy the link directly to the clipboard instead of opening the native share dialog.|No|Unchecked|
+|**Default User Name** (`default_user`)|Preselects the user when creating a token. This matches the Home Assistant user's **Name** field.|No|Empty|
+|**Default Dashboard/View Path** (`default_dashboard`)|Preselects dashboard or dashboard view when creating a token. Use `dashboard` or `dashboard/view` (examples: `lovelace-guest`, `lovelace-guest/entry`) and do not include a leading slash.|No|Empty|
 
 
 # Difference with the fork

--- a/custom_components/ha_guest_mode/config_flow.py
+++ b/custom_components/ha_guest_mode/config_flow.py
@@ -29,6 +29,8 @@ class GuestModeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional("path_to_admin_ui", default="/guest-mode"): str,
                 vol.Optional("login_path", default="/guest-mode/login"):str,
                 vol.Optional("copy_link_mode", default=False): bool,
+                vol.Optional("default_user", default=""): str,
+                vol.Optional("default_dashboard", default=""): str,
             }),
         )
 

--- a/custom_components/ha_guest_mode/options_flow.py
+++ b/custom_components/ha_guest_mode/options_flow.py
@@ -23,6 +23,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         path = self.config_entry.options.get("path_to_admin_ui", self.config_entry.data.get("path_to_admin_ui", "/guest-mode"))
         login_path = self.config_entry.options.get("login_path", self.config_entry.data.get("login_path", "/guest-mode/login"))
         copy_link = self.config_entry.options.get("copy_link_mode", self.config_entry.data.get("copy_link_mode", False))
+        default_user = self.config_entry.options.get("default_user", self.config_entry.data.get("default_user", ""))
+        default_dashboard = self.config_entry.options.get("default_dashboard", self.config_entry.data.get("default_dashboard", ""))
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema({
@@ -31,5 +33,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional("path_to_admin_ui", default=path): str,
                 vol.Optional("login_path", default=login_path): str,
                 vol.Optional("copy_link_mode", default=copy_link): bool,
+                vol.Optional("default_user", default=default_user): str,
+                vol.Optional("default_dashboard", default=default_dashboard): str,
             }),
         )

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -7,7 +7,13 @@
                     "tab_name": "Tab-Name",
                     "path_to_admin_ui": "Pfad zur Admin-Oberfläche",
                     "login_path": "Gast-Login-Pfad",
-                    "copy_link_mode": "Link direkt kopieren (überspringt das Teilen)"
+                    "copy_link_mode": "Link direkt kopieren (überspringt das Teilen)",
+                    "default_user": "Standard-Benutzername",
+                    "default_dashboard": "Standard-Dashboard-/View-Pfad"
+                },
+                "data_description": {
+                    "default_user": "Entspricht dem Feld Name des Home-Assistant-Benutzers.",
+                    "default_dashboard": "Verwenden Sie dashboard oder dashboard/view (z. B. lovelace-guest oder lovelace-guest/eingang). Keinen führenden Schrägstrich angeben."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Tab-Name",
                     "path_to_admin_ui": "Pfad zur Admin-Oberfläche",
                     "login_path": "Gast-Login-Pfad",
-                    "copy_link_mode": "Link direkt kopieren (überspringt das Teilen)"
+                    "copy_link_mode": "Link direkt kopieren (überspringt das Teilen)",
+                    "default_user": "Standard-Benutzername",
+                    "default_dashboard": "Standard-Dashboard-/View-Pfad"
+                },
+                "data_description": {
+                    "default_user": "Entspricht dem Feld Name des Home-Assistant-Benutzers.",
+                    "default_dashboard": "Verwenden Sie dashboard oder dashboard/view (z. B. lovelace-guest oder lovelace-guest/eingang). Keinen führenden Schrägstrich angeben."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -7,7 +7,13 @@
                     "tab_name": "Tab Name",
                     "path_to_admin_ui": "Path to Admin Interface",
                     "login_path": "Guest Login Path",
-                    "copy_link_mode": "Copy link directly (skips sharing)"
+                    "copy_link_mode": "Copy link directly (skips sharing)",
+                    "default_user": "Default User Name",
+                    "default_dashboard": "Default Dashboard/View Path"
+                },
+                "data_description": {
+                    "default_user": "Matches the Home Assistant user's Name field.",
+                    "default_dashboard": "Use dashboard or dashboard/view (example: lovelace-guest or lovelace-guest/entry). Do not include a leading slash."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Tab Name",
                     "path_to_admin_ui": "Path to Admin Interface",
                     "login_path": "Guest Login Path",
-                    "copy_link_mode": "Copy link directly (skips sharing)"
+                    "copy_link_mode": "Copy link directly (skips sharing)",
+                    "default_user": "Default User Name",
+                    "default_dashboard": "Default Dashboard/View Path"
+                },
+                "data_description": {
+                    "default_user": "Matches the Home Assistant user's Name field.",
+                    "default_dashboard": "Use dashboard or dashboard/view (example: lovelace-guest or lovelace-guest/entry). Do not include a leading slash."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -7,7 +7,13 @@
                     "tab_name": "Nombre de pestaña",
                     "path_to_admin_ui": "Ruta a la interfaz de administración",
                     "login_path": "Ruta de inicio de sesión de invitado",
-                    "copy_link_mode": "Copiar enlace directamente (omite compartir)"
+                    "copy_link_mode": "Copiar enlace directamente (omite compartir)",
+                    "default_user": "Nombre de usuario predeterminado",
+                    "default_dashboard": "Ruta predeterminada de tablero/vista"
+                },
+                "data_description": {
+                    "default_user": "Coincide con el campo Nombre del usuario de Home Assistant.",
+                    "default_dashboard": "Use dashboard o dashboard/view (por ejemplo: lovelace-guest o lovelace-guest/entrada). No incluya la barra inicial."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Nombre de pestaña",
                     "path_to_admin_ui": "Ruta a la interfaz de administración",
                     "login_path": "Ruta de inicio de sesión de invitado",
-                    "copy_link_mode": "Copiar enlace directamente (omite compartir)"
+                    "copy_link_mode": "Copiar enlace directamente (omite compartir)",
+                    "default_user": "Nombre de usuario predeterminado",
+                    "default_dashboard": "Ruta predeterminada de tablero/vista"
+                },
+                "data_description": {
+                    "default_user": "Coincide con el campo Nombre del usuario de Home Assistant.",
+                    "default_dashboard": "Use dashboard o dashboard/view (por ejemplo: lovelace-guest o lovelace-guest/entrada). No incluya la barra inicial."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -7,7 +7,13 @@
                     "tab_name": "Nom de l'onglet",
                     "path_to_admin_ui": "Chemin vers l'interface d'administration",
                     "login_path": "Chemin de connexion des invités",
-                    "copy_link_mode": "Copier le lien directement (ignore le partage)"
+                    "copy_link_mode": "Copier le lien directement (ignore le partage)",
+                    "default_user": "Nom de l'utilisateur par défaut",
+                    "default_dashboard": "Chemin tableau de bord/vue par défaut"
+                },
+                "data_description": {
+                    "default_user": "Correspond au champ Nom de l'utilisateur Home Assistant.",
+                    "default_dashboard": "Utilisez dashboard ou dashboard/view (exemple : lovelace-guest ou lovelace-guest/entree). N'incluez pas de slash initial."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Nom de l'onglet",
                     "path_to_admin_ui": "Chemin vers l'interface d'administration",
                     "login_path": "Chemin de connexion des invités",
-                    "copy_link_mode": "Copier le lien directement (ignore le partage)"
+                    "copy_link_mode": "Copier le lien directement (ignore le partage)",
+                    "default_user": "Nom de l'utilisateur par défaut",
+                    "default_dashboard": "Chemin tableau de bord/vue par défaut"
+                },
+                "data_description": {
+                    "default_user": "Correspond au champ Nom de l'utilisateur Home Assistant.",
+                    "default_dashboard": "Utilisez dashboard ou dashboard/view (exemple : lovelace-guest ou lovelace-guest/entree). N'incluez pas de slash initial."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -7,7 +7,13 @@
                     "tab_name": "Nome della scheda",
                     "path_to_admin_ui": "Percorso all'interfaccia amministrativa",
                     "login_path": "Percorso di accesso ospite",
-                    "copy_link_mode": "Copia il link direttamente (salta la condivisione)"
+                    "copy_link_mode": "Copia il link direttamente (salta la condivisione)",
+                    "default_user": "Nome utente predefinito",
+                    "default_dashboard": "Percorso predefinito dashboard/vista"
+                },
+                "data_description": {
+                    "default_user": "Corrisponde al campo Nome dell'utente di Home Assistant.",
+                    "default_dashboard": "Usa dashboard o dashboard/view (esempio: lovelace-guest o lovelace-guest/ingresso). Non includere la barra iniziale."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Nome della scheda",
                     "path_to_admin_ui": "Percorso all'interfaccia amministrativa",
                     "login_path": "Percorso di accesso ospite",
-                    "copy_link_mode": "Copia il link direttamente (salta la condivisione)"
+                    "copy_link_mode": "Copia il link direttamente (salta la condivisione)",
+                    "default_user": "Nome utente predefinito",
+                    "default_dashboard": "Percorso predefinito dashboard/vista"
+                },
+                "data_description": {
+                    "default_user": "Corrisponde al campo Nome dell'utente di Home Assistant.",
+                    "default_dashboard": "Usa dashboard o dashboard/view (esempio: lovelace-guest o lovelace-guest/ingresso). Non includere la barra iniziale."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -7,7 +7,13 @@
                     "tab_name": "Tab naam",
                     "path_to_admin_ui": "Pad naar admin-interface",
                     "login_path": "Gast login-pad",
-                    "copy_link_mode": "Kopieer de link direct (slaat delen over)"
+                    "copy_link_mode": "Kopieer de link direct (slaat delen over)",
+                    "default_user": "Standaard gebruikersnaam",
+                    "default_dashboard": "Standaard dashboard-/viewpad"
+                },
+                "data_description": {
+                    "default_user": "Komt overeen met het veld Naam van de Home Assistant-gebruiker.",
+                    "default_dashboard": "Gebruik dashboard of dashboard/view (bijv. lovelace-guest of lovelace-guest/entree). Voeg geen voorloopslash toe."
                 }
             }
         },
@@ -24,7 +30,13 @@
                     "tab_name": "Tab naam",
                     "path_to_admin_ui": "Pad naar admin-interface",
                     "login_path": "Gast login-pad",
-                    "copy_link_mode": "Kopieer de link direct (slaat delen over)"
+                    "copy_link_mode": "Kopieer de link direct (slaat delen over)",
+                    "default_user": "Standaard gebruikersnaam",
+                    "default_dashboard": "Standaard dashboard-/viewpad"
+                },
+                "data_description": {
+                    "default_user": "Komt overeen met het veld Naam van de Home Assistant-gebruiker.",
+                    "default_dashboard": "Gebruik dashboard of dashboard/view (bijv. lovelace-guest of lovelace-guest/entree). Voeg geen voorloopslash toe."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/websocketCommands.py
+++ b/custom_components/ha_guest_mode/websocketCommands.py
@@ -496,3 +496,18 @@ async def get_copy_link_mode(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     connection.send_result(msg["id"], hass.data.get("copy_link_mode"))
+
+
+@websocket_api.websocket_command({vol.Required("type"): "ha_guest_mode/get_token_defaults"})
+@websocket_api.require_admin
+@websocket_api.async_response
+async def get_token_defaults(
+    hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
+) -> None:
+    connection.send_result(
+        msg["id"],
+        {
+            "default_user": hass.data.get("default_user", ""),
+            "default_dashboard": hass.data.get("default_dashboard", ""),
+        },
+    )


### PR DESCRIPTION
## Summary
- add `default_user` and `default_dashboard` to both config flow and options flow
- preload defaults in the token creation UI, matching user by `name` and applying dashboard/view only when available
- add translation labels/descriptions, document both options in README, and fix frontend panel unload compatibility on recent Home Assistant versions

## Validation
- python3 -m compileall custom_components/ha_guest_mode
- translation JSON parsing check