### PR TITLE
Fix frontend dialog actions

### DIFF
--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Hinzufügen"
             },
+            "close": {
+                "name": "Schließen"
+            },
             "for": {
                 "name": "Für"
             },

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Schließen"
             },
+            "copy": {
+                "name": "Kopieren"
+            },
+            "copied_to_clipboard": {
+                "name": "In die Zwischenablage kopiert"
+            },
             "for": {
                 "name": "Für"
             },

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Close"
             },
+            "copy": {
+                "name": "Copy"
+            },
+            "copied_to_clipboard": {
+                "name": "Copied to clipboard"
+            },
             "for": {
                 "name": "For"
             },

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Add"
             },
+            "close": {
+                "name": "Close"
+            },
             "for": {
                 "name": "For"
             },

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Cerrar"
             },
+            "copy": {
+                "name": "Copiar"
+            },
+            "copied_to_clipboard": {
+                "name": "Copiado al portapapeles"
+            },
             "for": {
                 "name": "Para"
             },

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Añadir"
             },
+            "close": {
+                "name": "Cerrar"
+            },
             "for": {
                 "name": "Para"
             },

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Ajouter"
             },
+            "close": {
+                "name": "Fermer"
+            },
             "for": {
                 "name": "Pour"
             },

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Fermer"
             },
+            "copy": {
+                "name": "Copier"
+            },
+            "copied_to_clipboard": {
+                "name": "Copié dans le presse-papiers"
+            },
             "for": {
                 "name": "Pour"
             },

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Chiudi"
             },
+            "copy": {
+                "name": "Copia"
+            },
+            "copied_to_clipboard": {
+                "name": "Copiato negli appunti"
+            },
             "for": {
                 "name": "Per"
             },

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Aggiungi"
             },
+            "close": {
+                "name": "Chiudi"
+            },
             "for": {
                 "name": "Per"
             },

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -102,6 +102,9 @@
             "add": {
                 "name": "Toevoegen"
             },
+            "close": {
+                "name": "Sluiten"
+            },
             "for": {
                 "name": "voor"
             },

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -105,6 +105,12 @@
             "close": {
                 "name": "Sluiten"
             },
+            "copy": {
+                "name": "Kopiëren"
+            },
+            "copied_to_clipboard": {
+                "name": "Gekopieerd naar klembord"
+            },
             "for": {
                 "name": "voor"
             },

--- a/custom_components/ha_guest_mode/www/ha-guest-mode.js
+++ b/custom_components/ha_guest_mode/www/ha-guest-mode.js
@@ -599,7 +599,7 @@ class GuestModePanel extends LitElement {
             .catch((error) => console.error("Erreur de partage :", error));
     } else {
         navigator.clipboard.writeText(this.getLoginUrl(token, baseUrl));
-        this.showAlert('Copied to clipboard ' + token.name);
+        this.showAlert(`${this.translate("copied_to_clipboard") || "Copied to clipboard"} ${token.name}`);
     }
   }
 
@@ -651,7 +651,7 @@ class GuestModePanel extends LitElement {
     copyBtn.addEventListener('click', async () => {
       await navigator.clipboard.writeText(url);
       this.alertType = "info";
-      this.showAlert('Copied to clipboard');
+      this.showAlert(this.translate("copied_to_clipboard") || "Copied to clipboard");
     });
 
     const closeBtn = document.createElement('ha-button');

--- a/custom_components/ha_guest_mode/www/ha-guest-mode.js
+++ b/custom_components/ha_guest_mode/www/ha-guest-mode.js
@@ -406,7 +406,10 @@ class GuestModePanel extends LitElement {
     return group ? (group.name || group.id) : groupId;
   }
 
-  addClick() {
+  addClick(e) {
+    e?.preventDefault?.();
+    e?.stopPropagation?.();
+
     const payload = {
       type: 'ha_guest_mode/create_token',
       name: this.name,
@@ -654,7 +657,9 @@ class GuestModePanel extends LitElement {
     const closeBtn = document.createElement('ha-button');
     closeBtn.slot = 'secondaryAction';
     closeBtn.textContent = this.translate("close") || "Close";
-    closeBtn.addEventListener('click', () => dialog.close());
+    closeBtn.addEventListener('click', () => {
+      dialog.open = false;
+    });
 
     dialog.appendChild(container);
     footer.appendChild(closeBtn);
@@ -691,7 +696,7 @@ class GuestModePanel extends LitElement {
       confirmButton.textContent = buttons.confirm;
       confirmButton.addEventListener('click', () => {
         resolve(true);
-        dialog.close();
+        dialog.open = false;
       });
 
       const cancelButton = document.createElement('ha-button');
@@ -700,7 +705,7 @@ class GuestModePanel extends LitElement {
       cancelButton.textContent = buttons.cancel;
       cancelButton.addEventListener('click', () => {
         resolve(false);
-        dialog.close();
+        dialog.open = false;
       });
 
       footer.appendChild(cancelButton);
@@ -719,13 +724,19 @@ class GuestModePanel extends LitElement {
     return this.hass.localize(`component.ha_guest_mode.entity.frontend.${key}.name`);
   }
 
-  openCreateDialog() {
+  openCreateDialog(e) {
+    e?.preventDefault?.();
+    e?.stopPropagation?.();
+
     this.applyTokenDefaults();
     this.isCreateDialogOpen = true;
     this.modalAlert = '';
   }
 
-  closeCreateDialog() {
+  closeCreateDialog(e) {
+    e?.preventDefault?.();
+    e?.stopPropagation?.();
+
     this.isCreateDialogOpen = false;
     this.modalAlert = '';
   }
@@ -1037,7 +1048,7 @@ class GuestModePanel extends LitElement {
                 class="header-create-button"
                 title=${`${this.translate("create_token") || "Create token"} (${this.getCreateTokenShortcutLabel()})`}
                 aria-label=${this.translate("create_token") || "Create token"}
-                @click=${this.openCreateDialog}
+                @click=${(e) => this.openCreateDialog(e)}
               >
                 <ha-icon icon="mdi:plus"></ha-icon>
               </mwc-icon-button>
@@ -1048,7 +1059,7 @@ class GuestModePanel extends LitElement {
 
         <div class="mdc-top-app-bar--fixed-adjust flex content">
           ${this.isCreateDialogOpen ? html`
-            <ha-dialog class="create-token-dialog" open width="large" header-title=${this.translate("create_token") || "Create token"} @closed=${this.closeCreateDialog}>
+            <ha-dialog class="create-token-dialog" open width="large" header-title=${this.translate("create_token") || "Create token"} @closed=${(e) => this.closeCreateDialog(e)}>
               <div class="dialog-content">
                 ${this.renderCreateTokenForm(userSchema, groupSchema, dashboardSchema)}
               </div>
@@ -1062,10 +1073,10 @@ class GuestModePanel extends LitElement {
                   `
                 : null}
               <ha-dialog-footer slot="footer">
-                <ha-button slot="secondaryAction" @click=${this.closeCreateDialog}>
+                <ha-button slot="secondaryAction" @click=${(e) => this.closeCreateDialog(e)}>
                   ${this.translate("close") || "Close"}
                 </ha-button>
-                <ha-button slot="primaryAction" @click=${this.addClick}>
+                <ha-button slot="primaryAction" @click=${(e) => this.addClick(e)}>
                   ${this.translate("add")}
                 </ha-button>
               </ha-dialog-footer>
@@ -1134,7 +1145,7 @@ class GuestModePanel extends LitElement {
                 <div class="empty-state-content">
                   <h3>${this.translate("no_tokens_title") || "No active tokens"}</h3>
                   <p>${this.translate("no_tokens_description") || "Create one now to share guest access."}</p>
-                  <ha-button @click=${this.openCreateDialog}>
+                  <ha-button @click=${(e) => this.openCreateDialog(e)}>
                     ${this.translate("create_token") || "Create token"}
                   </ha-button>
                 </div>


### PR DESCRIPTION
## Summary
- Restore Create/Add/Close click handling with explicit event wrappers.
- Close temporary QR/share dialogs by updating their `open` state instead of calling `dialog.close()`.
- Add missing `close` frontend translations for supported languages.

## Testing
- `git diff --check`
- Restarted Home Assistant and checked recent logs for guest-mode errors