### PR TITLE
feat: add schedule-based guest access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The integration provides:
 
 * A redesigned admin interface to create, view, share, and manage guest access links.
 * Temporary links with optional start date, expiration date, duration, and usage limit.
+* Optional schedule-based access, allowing guest access only while a `schedule.*` entity is `on`.
 * Native Home Assistant login using a selected guest user.
 * Optional dashboard or dashboard view redirection after login.
 * QR code generation for the latest guest link, exposed through the `image.guest_qr_code` entity.
@@ -54,7 +55,7 @@ The integration provides:
 * Token status tracking, so you can see whether a guest link has already been used.
 * Home Assistant services, allowing guest tokens to be created from automations.
 
-For security, the Home Assistant long-lived access token is created only when the guest opens a valid link during the allowed time window and before the usage limit is reached.
+For security, the Home Assistant long-lived access token is created only when the guest opens a valid link during the allowed time window, while the optional schedule is active, and before the usage limit is reached. When a configured schedule turns off, Guest Mode revokes the Home Assistant refresh token it created for that guest token. It does not disable or remove the Home Assistant user.
 
 # Use case
 
@@ -82,12 +83,13 @@ Creates a new guest mode token.
 
 | Parameter | Description | Required |
 |---|---|---|
-| `user_id` | The name of the user to create the token for. | Yes |
+| `username` | The name of the user to create the token for. | Yes |
 | `token_name` | The name of the token. | No |
 | `expiration_duration` | The duration until the token expires (e.g., '02:00:00'). | No |
 | `expiration_date` | The date when the token expires. | No |
 | `start_date` | The date when the token becomes valid. | No |
 | `dashboard` | The URL path of the desired dashboard (e.g., 'lovelace-guest'). Do not include the leading slash. | No |
+| `schedule_entity_id` | Optional `schedule.*` entity. If set, guests can only access while this schedule is `on`; access tokens created by Guest Mode are revoked when it turns off. | No |
 
 **Note:** If neither `expiration_duration` nor `expiration_date` is provided, the token will never expire.
 
@@ -96,7 +98,7 @@ Creates a new guest mode token.
 ```yaml
 - service: ha_guest_mode.create_token
   data:
-    user_id: "guest"
+    username: "guest"
     token_name: "My Guest Token"
     expiration_duration: "01:00:00" # 1 hour
 ```

--- a/custom_components/ha_guest_mode/__init__.py
+++ b/custom_components/ha_guest_mode/__init__.py
@@ -18,6 +18,7 @@ from .keyManager import KeyManager
 from .const import DOMAIN, DATABASE, DEST_PATH_SCRIPT_JS, LEGACY_DATABASE, SOURCE_PATH_SCRIPT_JS, SCRIPT_JS
 from .services import async_register_services
 from .migrations import migration
+from .schedule_access import async_setup_schedule_access, async_unload_schedule_access
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
@@ -95,7 +96,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             managed_user BOOLEAN DEFAULT 0,
             managed_user_name TEXT,
             managed_user_groups TEXT,
-            managed_user_local_only BOOLEAN
+            managed_user_local_only BOOLEAN,
+            schedule_entity_id TEXT
         )
         """
     )
@@ -158,6 +160,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.http.register_view(ValidateTokenView(hass))
 
+    await async_setup_schedule_access(hass)
+
     await hass.config_entries.async_forward_entry_setups(config_entry, ["image"])
 
     return True
@@ -171,6 +175,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     panels = hass.data.get("frontend_panels", {})
     if path in panels:
         frontend.async_remove_panel(hass, path)
+
+    await async_unload_schedule_access(hass)
 
     await hass.config_entries.async_unload_platforms(config_entry, ["image"])
     return True

--- a/custom_components/ha_guest_mode/migrations.py
+++ b/custom_components/ha_guest_mode/migrations.py
@@ -73,3 +73,6 @@ def migration(cursor):
 
     if "managed_user_local_only" not in columns:
         cursor.execute("ALTER TABLE tokens ADD COLUMN managed_user_local_only BOOLEAN")
+
+    if "schedule_entity_id" not in columns:
+        cursor.execute("ALTER TABLE tokens ADD COLUMN schedule_entity_id TEXT")

--- a/custom_components/ha_guest_mode/schedule_access.py
+++ b/custom_components/ha_guest_mode/schedule_access.py
@@ -1,0 +1,153 @@
+import logging
+import sqlite3
+from contextlib import suppress
+from typing import Callable
+
+from homeassistant.const import STATE_ON
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DATABASE, DOMAIN
+from .utils import is_schedule_entity_active, normalize_schedule_entity_id
+
+
+_LOGGER = logging.getLogger(__name__)
+_SCHEDULE_LISTENERS = "schedule_access_listeners"
+
+
+def _get_schedule_listeners(hass: HomeAssistant) -> dict[str, Callable[[], None]]:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    return domain_data.setdefault(_SCHEDULE_LISTENERS, {})
+
+
+def _get_configured_schedule_entity_ids(hass: HomeAssistant) -> set[str]:
+    schedule_entity_ids = set()
+    for schedule_entity_id in _get_stored_schedule_entity_ids(hass):
+        try:
+            schedule_entity_ids.add(normalize_schedule_entity_id(schedule_entity_id))
+        except ValueError:
+            _LOGGER.warning("Ignoring invalid schedule entity id: %s", schedule_entity_id)
+
+    return {entity_id for entity_id in schedule_entity_ids if entity_id}
+
+
+def _get_stored_schedule_entity_ids(hass: HomeAssistant, only_used_tokens: bool = False) -> set[str]:
+    conn = sqlite3.connect(hass.config.path(DATABASE))
+    cursor = conn.cursor()
+    query = """
+        SELECT DISTINCT schedule_entity_id
+        FROM tokens
+        WHERE schedule_entity_id IS NOT NULL AND TRIM(schedule_entity_id) != ''
+        """
+    if only_used_tokens:
+        query += " AND token_ha_id IS NOT NULL AND token_ha_id != ''"
+
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    conn.close()
+    return {schedule_entity_id for (schedule_entity_id,) in rows if schedule_entity_id}
+
+
+async def async_revoke_schedule_tokens(hass: HomeAssistant, schedule_entity_id: str) -> None:
+    """Revoke HA refresh tokens created by Guest Mode for one schedule."""
+    conn = sqlite3.connect(hass.config.path(DATABASE))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, token_ha_id
+        FROM tokens
+        WHERE schedule_entity_id = ? AND token_ha_id IS NOT NULL AND token_ha_id != ''
+        """,
+        (schedule_entity_id,),
+    )
+    tokens = cursor.fetchall()
+
+    if not tokens:
+        conn.close()
+        return
+
+    revoked_token_ids = []
+    failed_token_ids = []
+    for token in tokens:
+        refresh_token_id = token["token_ha_id"]
+        try:
+            refresh_token = hass.auth.async_get_refresh_token(refresh_token_id)
+            if refresh_token:
+                hass.auth.async_remove_refresh_token(refresh_token)
+            revoked_token_ids.append(token["id"])
+        except Exception:
+            failed_token_ids.append(token["id"])
+            _LOGGER.exception(
+                "Failed to revoke Guest Mode refresh token %s for schedule %s",
+                refresh_token_id,
+                schedule_entity_id,
+            )
+
+    if revoked_token_ids:
+        cursor.executemany(
+            "UPDATE tokens SET token_ha_id = ?, token_ha = ? WHERE id = ?",
+            [("", "", token_id) for token_id in revoked_token_ids],
+        )
+        conn.commit()
+    conn.close()
+
+    _LOGGER.info(
+        "Revoked %s Guest Mode token(s) because %s is not active",
+        len(revoked_token_ids),
+        schedule_entity_id,
+    )
+    if failed_token_ids:
+        _LOGGER.warning(
+            "Failed to revoke %s Guest Mode token(s) for %s; keeping token IDs for retry",
+            len(failed_token_ids),
+            schedule_entity_id,
+        )
+
+
+async def async_revoke_inactive_scheduled_tokens(hass: HomeAssistant) -> None:
+    """Revoke Guest Mode refresh tokens for schedules that are not currently on."""
+    for schedule_entity_id in _get_stored_schedule_entity_ids(hass, only_used_tokens=True):
+        if not is_schedule_entity_active(hass, schedule_entity_id):
+            await async_revoke_schedule_tokens(hass, schedule_entity_id)
+
+
+async def async_refresh_schedule_listeners(hass: HomeAssistant) -> None:
+    """Synchronize state listeners with the schedules currently used by tokens."""
+    desired_entity_ids = _get_configured_schedule_entity_ids(hass)
+    listeners = _get_schedule_listeners(hass)
+
+    for entity_id in set(listeners) - desired_entity_ids:
+        with suppress(Exception):
+            listeners.pop(entity_id)()
+
+    for entity_id in desired_entity_ids - set(listeners):
+
+        @callback
+        def _async_schedule_changed(
+            event: Event, tracked_entity_id: str = entity_id
+        ) -> None:
+            new_state = event.data.get("new_state")
+            if new_state is not None and new_state.state == STATE_ON:
+                return
+
+            hass.async_create_task(async_revoke_schedule_tokens(hass, tracked_entity_id))
+
+        listeners[entity_id] = async_track_state_change_event(
+            hass, entity_id, _async_schedule_changed
+        )
+
+
+async def async_setup_schedule_access(hass: HomeAssistant) -> None:
+    """Set up schedule listeners and enforce current schedule states."""
+    await async_refresh_schedule_listeners(hass)
+    await async_revoke_inactive_scheduled_tokens(hass)
+
+
+async def async_unload_schedule_access(hass: HomeAssistant) -> None:
+    """Remove all schedule listeners."""
+    listeners = _get_schedule_listeners(hass)
+    for unsubscribe in list(listeners.values()):
+        with suppress(Exception):
+            unsubscribe()
+    listeners.clear()

--- a/custom_components/ha_guest_mode/services.py
+++ b/custom_components/ha_guest_mode/services.py
@@ -8,7 +8,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.translation import async_get_translations
 
 from .const import DOMAIN, DATABASE
-from .utils import as_utc_datetime, async_update_qr_code_entity, utcnow
+from .schedule_access import async_refresh_schedule_listeners
+from .utils import as_utc_datetime, async_update_qr_code_entity, normalize_schedule_entity_id, utcnow
 
 async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
     translations = await async_get_translations(hass, hass.config.language, "config")
@@ -19,6 +20,10 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
     expiration_date = call.data.get("expiration_date")
     start_date = call.data.get("start_date")
     dashboard = call.data.get("dashboard", "lovelace")
+    try:
+        schedule_entity_id = normalize_schedule_entity_id(call.data.get("schedule_entity_id"))
+    except ValueError as err:
+        raise vol.Invalid(str(err)) from err
 
     users = await hass.auth.async_get_users()
     user_id = None
@@ -93,9 +98,10 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
             managed_user,
             managed_user_name,
             managed_user_groups,
-            managed_user_local_only
+            managed_user_local_only,
+            schedule_entity_id
         )
-        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
     conn = sqlite3.connect(hass.config.path(DATABASE))
     cursor = conn.cursor()
@@ -117,11 +123,13 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
             None,
             None,
             None,
+            schedule_entity_id,
         ),
     )
     conn.commit()
     conn.close()
 
+    await async_refresh_schedule_listeners(hass)
     await async_update_qr_code_entity(hass)
 
 async def async_register_services(hass: HomeAssistant):
@@ -132,6 +140,7 @@ async def async_register_services(hass: HomeAssistant):
         vol.Exclusive("expiration_date", "expiration"): cv.datetime,
         vol.Optional("start_date"): cv.datetime,
         vol.Optional("dashboard"): cv.string,
+        vol.Optional("schedule_entity_id"): vol.Any(None, cv.entity_id),
     })
 
     async def async_handle_create_token(call: ServiceCall):

--- a/custom_components/ha_guest_mode/services.yaml
+++ b/custom_components/ha_guest_mode/services.yaml
@@ -22,3 +22,8 @@ create_token:
       example: "lovelace-guest"
       selector:
         text: {}
+    schedule_entity_id:
+      example: "schedule.guest_access"
+      selector:
+        entity:
+          domain: schedule

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Dashboard",
                     "description": "Der URL-Pfad des gewünschten Dashboards (z. B. 'lovelace-guest'). Fügen Sie den führenden Schrägstrich nicht hinzu."
+                },
+                "schedule_entity_id": {
+                    "name": "Zeitplan-Entität",
+                    "description": "Optionale schedule.*-Entität. Wenn gesetzt, wird der Gastzugriff widerrufen, sobald der Zeitplan nicht an ist."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Dashboard (optional)"
+            },
+            "schedule_entity": {
+                "name": "Zeitplan-Entität (optional)"
+            },
+            "schedule": {
+                "name": "Zeitplan"
+            },
+            "schedule_placeholder": {
+                "name": "Zeitplan auswählen (optional)"
             },
             "default_dashboard": {
                 "name": "Standard-Dashboard"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "Das Nutzungslimit für dieses Token wurde erreicht."
+            },
+            "schedule_not_active": {
+                "name": "Der Gastzugriff liegt derzeit außerhalb des erlaubten Zeitplans."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Dashboard",
                     "description": "The URL path of the desired dashboard (e.g., 'lovelace-guest'). Do not include the leading slash."
+                },
+                "schedule_entity_id": {
+                    "name": "Schedule entity",
+                    "description": "Optional schedule.* entity. If set, guest access is revoked when the schedule is not on."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Dashboard (optional)"
+            },
+            "schedule_entity": {
+                "name": "Schedule entity (optional)"
+            },
+            "schedule": {
+                "name": "Schedule"
+            },
+            "schedule_placeholder": {
+                "name": "Select a schedule (optional)"
             },
             "default_dashboard": {
                 "name": "Default Dashboard"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "The usage limit for this token has been reached."
+            },
+            "schedule_not_active": {
+                "name": "Guest access is currently outside the allowed schedule."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Tablero",
                     "description": "La ruta de la URL del tablero deseado (por ejemplo, 'lovelace-guest'). No incluya la barra inclinada inicial."
+                },
+                "schedule_entity_id": {
+                    "name": "Entidad de horario",
+                    "description": "Entidad schedule.* opcional. Si se define, el acceso de invitado se revoca cuando el horario no está activado."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Tablero (opcional)"
+            },
+            "schedule_entity": {
+                "name": "Entidad de horario (opcional)"
+            },
+            "schedule": {
+                "name": "Horario"
+            },
+            "schedule_placeholder": {
+                "name": "Seleccionar un horario (opcional)"
             },
             "default_dashboard": {
                 "name": "Tablero predeterminado"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "Se ha alcanzado el límite de uso para este token."
+            },
+            "schedule_not_active": {
+                "name": "El acceso de invitado está actualmente fuera del horario permitido."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Tableau de bord",
                     "description": "Le chemin de l'URL du tableau de bord souhaité (par exemple, 'lovelace-guest'). N'incluez pas le slash au début."
+                },
+                "schedule_entity_id": {
+                    "name": "Entité planning",
+                    "description": "Entité schedule.* optionnelle. Si elle est définie, l'accès invité est révoqué lorsque le planning n'est pas activé."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Tableau de bord (optionnel)"
+            },
+            "schedule_entity": {
+                "name": "Entité planning (optionnelle)"
+            },
+            "schedule": {
+                "name": "Planning"
+            },
+            "schedule_placeholder": {
+                "name": "Sélectionner un planning (optionnel)"
             },
             "default_dashboard": {
                 "name": "Tableau de bord par défaut"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "La limite d'utilisation pour ce jeton a été atteinte."
+            },
+            "schedule_not_active": {
+                "name": "L'accès invité est actuellement hors des plages horaires autorisées."
             }
         }   
     }

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Cruscotto",
                     "description": "Il percorso URL del cruscotto desiderato (ad es. 'lovelace-guest'). Non includere la barra iniziale."
+                },
+                "schedule_entity_id": {
+                    "name": "Entità pianificazione",
+                    "description": "Entità schedule.* opzionale. Se impostata, l'accesso ospite viene revocato quando la pianificazione non è attiva."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Cruscotto (opzionale)"
+            },
+            "schedule_entity": {
+                "name": "Entità pianificazione (opzionale)"
+            },
+            "schedule": {
+                "name": "Pianificazione"
+            },
+            "schedule_placeholder": {
+                "name": "Seleziona una pianificazione (opzionale)"
             },
             "default_dashboard": {
                 "name": "Cruscotto predefinito"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "Il limite di utilizzo per questo token è stato raggiunto."
+            },
+            "schedule_not_active": {
+                "name": "L'accesso ospite è attualmente fuori dall'orario consentito."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -69,6 +69,10 @@
                 "dashboard": {
                     "name": "Dashboard",
                     "description": "Het URL-pad van het gewenste dashboard (bijv. 'lovelace-guest'). Voeg de voorloop-slash niet toe."
+                },
+                "schedule_entity_id": {
+                    "name": "Schema-entiteit",
+                    "description": "Optionele schedule.*-entiteit. Indien ingesteld, wordt gasttoegang ingetrokken wanneer het schema niet aan staat."
                 }
             }
         }
@@ -146,6 +150,15 @@
             },
             "dashboard": {
                 "name": "Dashboard (optioneel)"
+            },
+            "schedule_entity": {
+                "name": "Schema-entiteit (optioneel)"
+            },
+            "schedule": {
+                "name": "Schema"
+            },
+            "schedule_placeholder": {
+                "name": "Schema selecteren (optioneel)"
             },
             "default_dashboard": {
                 "name": "Standaard dashboard"
@@ -235,6 +248,9 @@
             },
             "usage_limit_reached": {
                 "name": "De gebruikslimiet voor deze token is bereikt."
+            },
+            "schedule_not_active": {
+                "name": "Gasttoegang valt momenteel buiten het toegestane schema."
             }
         }
     }

--- a/custom_components/ha_guest_mode/utils.py
+++ b/custom_components/ha_guest_mode/utils.py
@@ -3,6 +3,7 @@ from inspect import isawaitable
 import logging
 
 from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_ON
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
@@ -43,6 +44,36 @@ def parse_utc_datetime(value: str) -> datetime:
     """
     parsed = dt_util.parse_datetime(value) or datetime.fromisoformat(value)
     return as_utc_datetime(parsed)
+
+
+def normalize_schedule_entity_id(value) -> str | None:
+    """Normalize and validate an optional schedule entity id."""
+    if value is None:
+        return None
+
+    entity_id = str(value).strip()
+    if not entity_id:
+        return None
+
+    domain, separator, object_id = entity_id.partition(".")
+    if domain != "schedule" or not separator or not object_id:
+        raise ValueError("schedule_entity_id must be a schedule entity")
+
+    return entity_id
+
+
+def is_schedule_entity_active(hass: HomeAssistant, value) -> bool:
+    """Return true only when the configured schedule exists and is on."""
+    try:
+        schedule_entity_id = normalize_schedule_entity_id(value)
+    except ValueError:
+        return False
+
+    if schedule_entity_id is None:
+        return True
+
+    schedule_state = hass.states.get(schedule_entity_id)
+    return schedule_state is not None and schedule_state.state == STATE_ON
 
 
 async def async_update_qr_code_entity(hass: HomeAssistant) -> None:

--- a/custom_components/ha_guest_mode/validateTokenView.py
+++ b/custom_components/ha_guest_mode/validateTokenView.py
@@ -11,7 +11,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers.translation import async_get_translations
 
 from .const import DATABASE, DOMAIN
-from .utils import async_sync_acm_dashboards, parse_utc_datetime, utcnow, utcnow_isoformat
+from .utils import async_sync_acm_dashboards, is_schedule_entity_active, parse_utc_datetime, utcnow, utcnow_isoformat
 
 class ValidateTokenView(HomeAssistantView):
     name = "guest-mode:login"
@@ -24,6 +24,12 @@ class ValidateTokenView(HomeAssistantView):
     def get_translations(self, translations: dict[str, Any], label: str):
         key = f"component.{DOMAIN}.entity.guest_error.{label}.name"
         return translations.get(key, f"Missing translation: {key}")
+
+    def _is_schedule_active(self, token_row: sqlite3.Row) -> bool:
+        if "schedule_entity_id" not in token_row.keys():
+            return True
+
+        return is_schedule_entity_active(self.hass, token_row["schedule_entity_id"])
 
     async def _restore_managed_user(self, cursor, token_row: sqlite3.Row):
         available_groups = []
@@ -102,6 +108,10 @@ class ValidateTokenView(HomeAssistantView):
         
         if result is None:
             return web.Response(status=404, text=self.get_translations(translations, "token_not_found"))
+
+        if not self._is_schedule_active(result):
+            conn.close()
+            return web.Response(status=403, text=self.get_translations(translations, "schedule_not_active"))
 
         try:
             first_used = result["first_used"]

--- a/custom_components/ha_guest_mode/websocketCommands.py
+++ b/custom_components/ha_guest_mode/websocketCommands.py
@@ -15,7 +15,8 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers import config_validation as cv
 
 from .const import DATABASE
-from .utils import async_sync_acm_dashboards, async_update_qr_code_entity, parse_utc_datetime, utcnow
+from .schedule_access import async_refresh_schedule_listeners
+from .utils import async_sync_acm_dashboards, async_update_qr_code_entity, normalize_schedule_entity_id, parse_utc_datetime, utcnow
 
 
 async def _async_get_all_groups(hass: HomeAssistant):
@@ -56,6 +57,7 @@ async def list_users(
     cursor.execute('SELECT * FROM tokens')
     token_rows = cursor.fetchall()
     sync_acm_needed = False
+    schedule_listeners_needed = False
 
     async def remove_managed_user_if_needed(user_id: str, managed: bool) -> None:
         nonlocal sync_acm_needed
@@ -91,6 +93,7 @@ async def list_users(
                             hass.auth.async_remove_refresh_token(refresh_token)
 
                 cursor.execute('DELETE FROM tokens WHERE id = ?', (token["id"],))
+                schedule_listeners_needed = True
                 await remove_managed_user_if_needed(token["userId"], bool(token.get("managed_user")))
                 continue
 
@@ -186,6 +189,7 @@ async def list_users(
                     "last_used": token["last_used"],
                     "times_used": token["times_used"] or 0,
                     "usage_limit": token["usage_limit"],
+                    "schedule_entity_id": token.get("schedule_entity_id"),
                 }
             )
 
@@ -204,6 +208,8 @@ async def list_users(
 
     conn.commit()
     conn.close()
+    if schedule_listeners_needed:
+        await async_refresh_schedule_listeners(hass)
     if sync_acm_needed:
         await async_sync_acm_dashboards(hass)
     connection.send_result(msg["id"], result)
@@ -241,6 +247,7 @@ async def list_groups(
         vol.Optional("new_user_name"): str,
         vol.Optional("group_ids"): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional("new_user_local_only", default=False): bool,
+        vol.Optional("schedule_entity_id"): vol.Any(str, None),
     }
 )
 @websocket_api.require_admin
@@ -260,6 +267,16 @@ async def create_token(
         managed_user_name = None
         managed_user_groups = None
         managed_user_local_only = None
+
+        try:
+            schedule_entity_id = normalize_schedule_entity_id(msg.get("schedule_entity_id"))
+        except ValueError as err:
+            connection.send_message(
+                websocket_api.error_message(
+                    msg["id"], websocket_api.const.ERR_INVALID_FORMAT, str(err)
+                )
+            )
+            return
 
         if not is_never_expire:
             if "startDate" not in msg or "expirationDate" not in msg:
@@ -358,9 +375,10 @@ async def create_token(
                 managed_user,
                 managed_user_name,
                 managed_user_groups,
-                managed_user_local_only
+                managed_user_local_only,
+                schedule_entity_id
             )
-            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         conn = sqlite3.connect(hass.config.path(DATABASE))
         cursor = conn.cursor()
@@ -382,10 +400,13 @@ async def create_token(
                 managed_user_name,
                 managed_user_groups,
                 managed_user_local_only,
+                schedule_entity_id,
             ),
         )
         conn.commit()
         conn.close()
+
+        await async_refresh_schedule_listeners(hass)
 
         if managed_user:
             await async_sync_acm_dashboards(hass)
@@ -445,6 +466,7 @@ async def delete_token(
 
     conn.commit()
     conn.close()
+    await async_refresh_schedule_listeners(hass)
     if sync_acm_needed:
         await async_sync_acm_dashboards(hass)
     connection.send_result(msg["id"], True)

--- a/custom_components/ha_guest_mode/www/ha-guest-mode.js
+++ b/custom_components/ha_guest_mode/www/ha-guest-mode.js
@@ -55,6 +55,7 @@ class GuestModePanel extends LitElement {
       urls: { type: Object },
       dashboards: { type: Array },
       dashboard: { type: String },
+      scheduleEntityId: { type: String },
       copyLinkMode: { type: Boolean },
       defaultUser: { type: String },
       defaultDashboard: { type: String },
@@ -80,6 +81,7 @@ class GuestModePanel extends LitElement {
     this.urls = {};
     this.dashboards = [];
     this.dashboard = '';
+    this.scheduleEntityId = '';
     this.copyLinkMode = false;
     this.defaultUser = '';
     this.defaultDashboard = '';
@@ -289,6 +291,7 @@ class GuestModePanel extends LitElement {
               last_used: token.last_used ? new Date(token.last_used).toLocaleString(userLocale).replace(/:\d{2}$/, "") : this.translate("never"),
               times_used: token.times_used || 0,
               usage_limit: token.usage_limit,
+              schedule_entity_id: token.schedule_entity_id || '',
             });
           });
       });
@@ -382,6 +385,11 @@ class GuestModePanel extends LitElement {
     this.dashboard = value || "";
   }
 
+  scheduleChanged(e) {
+    const value = e.detail?.value;
+    this.scheduleEntityId = value || "";
+  }
+
   groupSelected(e) {
     const value = e.detail?.value?.group;
     if (!value) {
@@ -427,6 +435,10 @@ class GuestModePanel extends LitElement {
 
     if (this.dashboard) {
       payload.dashboard = this.dashboard;
+    }
+
+    if (this.scheduleEntityId) {
+      payload.schedule_entity_id = this.scheduleEntityId;
     }
 
     if (!this.name) {
@@ -814,6 +826,14 @@ class GuestModePanel extends LitElement {
                 .data=${{ dashboard: this.dashboard || "" }}
                 @value-changed=${this.dashboardChanged}
               ></ha-form>
+              <ha-entity-picker
+                .hass=${this.hass}
+                .label=${""}
+                .placeholder=${this.translate("schedule_placeholder") || "Select a schedule (optional)"}
+                .value=${this.scheduleEntityId || ""}
+                .includeDomains=${["schedule"]}
+                @value-changed=${this.scheduleChanged}
+              ></ha-entity-picker>
               <ha-input
                 .label=${this.translate("usage_limit")}
                 type="number"
@@ -1114,6 +1134,7 @@ class GuestModePanel extends LitElement {
                       `}
                       ${this.translate("used")}: ${token.isUsed ? this.translate("yes").toLowerCase() : this.translate("no").toLowerCase() } <br>
                       ${this.translate("dashboard")}: ${dashboardTitle} <br>
+                      ${token.schedule_entity_id ? html`${this.translate("schedule")}: ${token.schedule_entity_id} <br>` : ''}
                       ${this.translate("first_used")}: ${token.first_used} <br>
                       ${this.translate("last_used")}: ${token.last_used} <br>
                       ${this.translate("times_used")}: ${token.times_used}${token.usage_limit ? ` / ${token.usage_limit}` : ''} <br>


### PR DESCRIPTION
## Summary
- Add optional schedule-based guest access tied to schedule.* entities.
- Revoke Guest Mode-created Home Assistant refresh tokens when configured schedules turn off.
- Surface schedule selection in services, websocket responses, UI, documentation, and translations.

## Testing
- git diff --check
- Python AST parse for changed Python files
- Translation JSON parse
- Not run: Home Assistant runtime integration tests