### PR TITLE
feat: add entity-controlled guest access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The integration provides:
 
 * A redesigned admin interface to create, view, share, and manage guest access links.
 * Temporary links with optional start date, expiration date, duration, and usage limit.
-* Optional schedule-based access, allowing guest access only while a `schedule.*` entity is `on`.
+* Optional entity-controlled access, allowing guest access only while a `schedule.*` or `input_boolean.*` entity is `on`.
 * Native Home Assistant login using a selected guest user.
 * Optional dashboard or dashboard view redirection after login.
 * QR code generation for the latest guest link, exposed through the `image.guest_qr_code` entity.
@@ -55,7 +55,7 @@ The integration provides:
 * Token status tracking, so you can see whether a guest link has already been used.
 * Home Assistant services, allowing guest tokens to be created from automations.
 
-For security, the Home Assistant long-lived access token is created only when the guest opens a valid link during the allowed time window, while the optional schedule is active, and before the usage limit is reached. When a configured schedule turns off, Guest Mode revokes the Home Assistant refresh token it created for that guest token. It does not disable or remove the Home Assistant user.
+For security, the Home Assistant long-lived access token is created only when the guest opens a valid link during the allowed time window, while the optional access control entity is `on`, and before the usage limit is reached. When that entity turns off, becomes unavailable, or is removed, Guest Mode revokes the Home Assistant refresh token it created for that guest token. It does not disable or remove the Home Assistant user.
 
 # Use case
 
@@ -89,7 +89,7 @@ Creates a new guest mode token.
 | `expiration_date` | The date when the token expires. | No |
 | `start_date` | The date when the token becomes valid. | No |
 | `dashboard` | The URL path of the desired dashboard (e.g., 'lovelace-guest'). Do not include the leading slash. | No |
-| `schedule_entity_id` | Optional `schedule.*` entity. If set, guests can only access while this schedule is `on`; access tokens created by Guest Mode are revoked when it turns off. | No |
+| `access_entity_id` | Optional `schedule.*` or `input_boolean.*` entity. Guests can only access while this entity is `on`; credentials created by Guest Mode are revoked when it stops being `on`. | No |
 
 **Note:** If neither `expiration_duration` nor `expiration_date` is provided, the token will never expire.
 
@@ -102,6 +102,18 @@ Creates a new guest mode token.
     token_name: "My Guest Token"
     expiration_duration: "01:00:00" # 1 hour
 ```
+
+For a reusable link controlled by a helper, omit the expiration fields and set an input boolean:
+
+```yaml
+- service: ha_guest_mode.create_token
+  data:
+    username: "guest"
+    token_name: "Recurring Guest"
+    access_entity_id: input_boolean.guest_access
+```
+
+The previous `schedule_entity_id` service field remains accepted for compatibility with existing automations.
 
 # Entities
 

--- a/custom_components/ha_guest_mode/__init__.py
+++ b/custom_components/ha_guest_mode/__init__.py
@@ -18,7 +18,7 @@ from .keyManager import KeyManager
 from .const import DOMAIN, DATABASE, DEST_PATH_SCRIPT_JS, LEGACY_DATABASE, SOURCE_PATH_SCRIPT_JS, SCRIPT_JS
 from .services import async_register_services
 from .migrations import migration
-from .schedule_access import async_setup_schedule_access, async_unload_schedule_access
+from .access_control import async_setup_access_control, async_unload_access_control
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
@@ -160,7 +160,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.http.register_view(ValidateTokenView(hass))
 
-    await async_setup_schedule_access(hass)
+    await async_setup_access_control(hass)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, ["image"])
 
@@ -176,7 +176,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     if path in panels:
         frontend.async_remove_panel(hass, path)
 
-    await async_unload_schedule_access(hass)
+    await async_unload_access_control(hass)
 
     await hass.config_entries.async_unload_platforms(config_entry, ["image"])
     return True

--- a/custom_components/ha_guest_mode/access_control.py
+++ b/custom_components/ha_guest_mode/access_control.py
@@ -8,30 +8,31 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import DATABASE, DOMAIN
-from .utils import is_schedule_entity_active, normalize_schedule_entity_id
+from .utils import is_access_entity_active, normalize_access_entity_id
 
 
 _LOGGER = logging.getLogger(__name__)
-_SCHEDULE_LISTENERS = "schedule_access_listeners"
+# Keep the existing hass.data key so listeners survive integration upgrades safely.
+_ACCESS_LISTENERS = "schedule_access_listeners"
 
 
-def _get_schedule_listeners(hass: HomeAssistant) -> dict[str, Callable[[], None]]:
+def _get_access_listeners(hass: HomeAssistant) -> dict[str, Callable[[], None]]:
     domain_data = hass.data.setdefault(DOMAIN, {})
-    return domain_data.setdefault(_SCHEDULE_LISTENERS, {})
+    return domain_data.setdefault(_ACCESS_LISTENERS, {})
 
 
-def _get_configured_schedule_entity_ids(hass: HomeAssistant) -> set[str]:
-    schedule_entity_ids = set()
-    for schedule_entity_id in _get_stored_schedule_entity_ids(hass):
+def _get_configured_access_entity_ids(hass: HomeAssistant) -> set[str]:
+    access_entity_ids = set()
+    for access_entity_id in _get_stored_access_entity_ids(hass):
         try:
-            schedule_entity_ids.add(normalize_schedule_entity_id(schedule_entity_id))
+            access_entity_ids.add(normalize_access_entity_id(access_entity_id))
         except ValueError:
-            _LOGGER.warning("Ignoring invalid schedule entity id: %s", schedule_entity_id)
+            _LOGGER.warning("Ignoring invalid access entity id: %s", access_entity_id)
 
-    return {entity_id for entity_id in schedule_entity_ids if entity_id}
+    return {entity_id for entity_id in access_entity_ids if entity_id}
 
 
-def _get_stored_schedule_entity_ids(hass: HomeAssistant, only_used_tokens: bool = False) -> set[str]:
+def _get_stored_access_entity_ids(hass: HomeAssistant, only_used_tokens: bool = False) -> set[str]:
     conn = sqlite3.connect(hass.config.path(DATABASE))
     cursor = conn.cursor()
     query = """
@@ -45,11 +46,11 @@ def _get_stored_schedule_entity_ids(hass: HomeAssistant, only_used_tokens: bool 
     cursor.execute(query)
     rows = cursor.fetchall()
     conn.close()
-    return {schedule_entity_id for (schedule_entity_id,) in rows if schedule_entity_id}
+    return {access_entity_id for (access_entity_id,) in rows if access_entity_id}
 
 
-async def async_revoke_schedule_tokens(hass: HomeAssistant, schedule_entity_id: str) -> None:
-    """Revoke HA refresh tokens created by Guest Mode for one schedule."""
+async def async_revoke_access_tokens(hass: HomeAssistant, access_entity_id: str) -> None:
+    """Revoke HA refresh tokens controlled by one access entity."""
     conn = sqlite3.connect(hass.config.path(DATABASE))
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
@@ -59,7 +60,7 @@ async def async_revoke_schedule_tokens(hass: HomeAssistant, schedule_entity_id: 
         FROM tokens
         WHERE schedule_entity_id = ? AND token_ha_id IS NOT NULL AND token_ha_id != ''
         """,
-        (schedule_entity_id,),
+        (access_entity_id,),
     )
     tokens = cursor.fetchall()
 
@@ -79,9 +80,9 @@ async def async_revoke_schedule_tokens(hass: HomeAssistant, schedule_entity_id: 
         except Exception:
             failed_token_ids.append(token["id"])
             _LOGGER.exception(
-                "Failed to revoke Guest Mode refresh token %s for schedule %s",
+                "Failed to revoke Guest Mode refresh token %s for access entity %s",
                 refresh_token_id,
-                schedule_entity_id,
+                access_entity_id,
             )
 
     if revoked_token_ids:
@@ -95,27 +96,27 @@ async def async_revoke_schedule_tokens(hass: HomeAssistant, schedule_entity_id: 
     _LOGGER.info(
         "Revoked %s Guest Mode token(s) because %s is not active",
         len(revoked_token_ids),
-        schedule_entity_id,
+        access_entity_id,
     )
     if failed_token_ids:
         _LOGGER.warning(
             "Failed to revoke %s Guest Mode token(s) for %s; keeping token IDs for retry",
             len(failed_token_ids),
-            schedule_entity_id,
+            access_entity_id,
         )
 
 
-async def async_revoke_inactive_scheduled_tokens(hass: HomeAssistant) -> None:
-    """Revoke Guest Mode refresh tokens for schedules that are not currently on."""
-    for schedule_entity_id in _get_stored_schedule_entity_ids(hass, only_used_tokens=True):
-        if not is_schedule_entity_active(hass, schedule_entity_id):
-            await async_revoke_schedule_tokens(hass, schedule_entity_id)
+async def async_revoke_inactive_access_tokens(hass: HomeAssistant) -> None:
+    """Revoke Guest Mode refresh tokens whose access entity is not on."""
+    for access_entity_id in _get_stored_access_entity_ids(hass, only_used_tokens=True):
+        if not is_access_entity_active(hass, access_entity_id):
+            await async_revoke_access_tokens(hass, access_entity_id)
 
 
-async def async_refresh_schedule_listeners(hass: HomeAssistant) -> None:
-    """Synchronize state listeners with the schedules currently used by tokens."""
-    desired_entity_ids = _get_configured_schedule_entity_ids(hass)
-    listeners = _get_schedule_listeners(hass)
+async def async_refresh_access_listeners(hass: HomeAssistant) -> None:
+    """Synchronize state listeners with access entities used by tokens."""
+    desired_entity_ids = _get_configured_access_entity_ids(hass)
+    listeners = _get_access_listeners(hass)
 
     for entity_id in set(listeners) - desired_entity_ids:
         with suppress(Exception):
@@ -124,29 +125,29 @@ async def async_refresh_schedule_listeners(hass: HomeAssistant) -> None:
     for entity_id in desired_entity_ids - set(listeners):
 
         @callback
-        def _async_schedule_changed(
+        def _async_access_entity_changed(
             event: Event, tracked_entity_id: str = entity_id
         ) -> None:
             new_state = event.data.get("new_state")
             if new_state is not None and new_state.state == STATE_ON:
                 return
 
-            hass.async_create_task(async_revoke_schedule_tokens(hass, tracked_entity_id))
+            hass.async_create_task(async_revoke_access_tokens(hass, tracked_entity_id))
 
         listeners[entity_id] = async_track_state_change_event(
-            hass, entity_id, _async_schedule_changed
+            hass, entity_id, _async_access_entity_changed
         )
 
 
-async def async_setup_schedule_access(hass: HomeAssistant) -> None:
-    """Set up schedule listeners and enforce current schedule states."""
-    await async_refresh_schedule_listeners(hass)
-    await async_revoke_inactive_scheduled_tokens(hass)
+async def async_setup_access_control(hass: HomeAssistant) -> None:
+    """Set up access listeners and enforce current entity states."""
+    await async_refresh_access_listeners(hass)
+    await async_revoke_inactive_access_tokens(hass)
 
 
-async def async_unload_schedule_access(hass: HomeAssistant) -> None:
-    """Remove all schedule listeners."""
-    listeners = _get_schedule_listeners(hass)
+async def async_unload_access_control(hass: HomeAssistant) -> None:
+    """Remove all access entity listeners."""
+    listeners = _get_access_listeners(hass)
     for unsubscribe in list(listeners.values()):
         with suppress(Exception):
             unsubscribe()

--- a/custom_components/ha_guest_mode/services.py
+++ b/custom_components/ha_guest_mode/services.py
@@ -8,8 +8,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.translation import async_get_translations
 
 from .const import DOMAIN, DATABASE
-from .schedule_access import async_refresh_schedule_listeners
-from .utils import as_utc_datetime, async_update_qr_code_entity, normalize_schedule_entity_id, utcnow
+from .access_control import async_refresh_access_listeners
+from .utils import as_utc_datetime, async_update_qr_code_entity, resolve_access_entity_id, utcnow
 
 async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
     translations = await async_get_translations(hass, hass.config.language, "config")
@@ -21,7 +21,9 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
     start_date = call.data.get("start_date")
     dashboard = call.data.get("dashboard", "lovelace")
     try:
-        schedule_entity_id = normalize_schedule_entity_id(call.data.get("schedule_entity_id"))
+        access_entity_id = resolve_access_entity_id(
+            call.data.get("access_entity_id"), call.data.get("schedule_entity_id")
+        )
     except ValueError as err:
         raise vol.Invalid(str(err)) from err
 
@@ -123,13 +125,13 @@ async def async_create_token_service(hass: HomeAssistant, call: ServiceCall):
             None,
             None,
             None,
-            schedule_entity_id,
+            access_entity_id,
         ),
     )
     conn.commit()
     conn.close()
 
-    await async_refresh_schedule_listeners(hass)
+    await async_refresh_access_listeners(hass)
     await async_update_qr_code_entity(hass)
 
 async def async_register_services(hass: HomeAssistant):
@@ -140,6 +142,7 @@ async def async_register_services(hass: HomeAssistant):
         vol.Exclusive("expiration_date", "expiration"): cv.datetime,
         vol.Optional("start_date"): cv.datetime,
         vol.Optional("dashboard"): cv.string,
+        vol.Optional("access_entity_id"): vol.Any(None, cv.entity_id),
         vol.Optional("schedule_entity_id"): vol.Any(None, cv.entity_id),
     })
 

--- a/custom_components/ha_guest_mode/services.yaml
+++ b/custom_components/ha_guest_mode/services.yaml
@@ -22,8 +22,10 @@ create_token:
       example: "lovelace-guest"
       selector:
         text: {}
-    schedule_entity_id:
-      example: "schedule.guest_access"
+    access_entity_id:
+      example: "input_boolean.guest_access"
       selector:
         entity:
-          domain: schedule
+          domain:
+            - schedule
+            - input_boolean

--- a/custom_components/ha_guest_mode/services.yaml
+++ b/custom_components/ha_guest_mode/services.yaml
@@ -29,3 +29,8 @@ create_token:
           domain:
             - schedule
             - input_boolean
+    schedule_entity_id:
+      example: "schedule.guest_access"
+      selector:
+        entity:
+          domain: schedule

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -70,9 +70,9 @@
                     "name": "Dashboard",
                     "description": "Der URL-Pfad des gewünschten Dashboards (z. B. 'lovelace-guest'). Fügen Sie den führenden Schrägstrich nicht hinzu."
                 },
-                "schedule_entity_id": {
-                    "name": "Zeitplan-Entität",
-                    "description": "Optionale schedule.*-Entität. Wenn gesetzt, wird der Gastzugriff widerrufen, sobald der Zeitplan nicht an ist."
+                "access_entity_id": {
+                    "name": "Zugriffssteuerungsentität",
+                    "description": "Optionale schedule.*- oder input_boolean.*-Entität. Gastzugriff ist nur erlaubt, solange sie eingeschaltet ist."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Dashboard (optional)"
             },
-            "schedule_entity": {
-                "name": "Zeitplan-Entität (optional)"
+            "access_entity": {
+                "name": "Zugriffssteuerungsentität"
             },
-            "schedule": {
-                "name": "Zeitplan"
-            },
-            "schedule_placeholder": {
-                "name": "Zeitplan auswählen (optional)"
+            "access_entity_placeholder": {
+                "name": "Zugriffssteuerungsentität auswählen (optional)"
             },
             "default_dashboard": {
                 "name": "Standard-Dashboard"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "Das Nutzungslimit für dieses Token wurde erreicht."
             },
-            "schedule_not_active": {
-                "name": "Der Gastzugriff liegt derzeit außerhalb des erlaubten Zeitplans."
+            "access_disabled": {
+                "name": "Der Gastzugriff ist derzeit deaktiviert."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/de.json
+++ b/custom_components/ha_guest_mode/translations/de.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Zugriffssteuerungsentität",
                     "description": "Optionale schedule.*- oder input_boolean.*-Entität. Gastzugriff ist nur erlaubt, solange sie eingeschaltet ist."
+                },
+                "schedule_entity_id": {
+                    "name": "Zeitplan-Entität (veraltet)",
+                    "description": "Veralteter Alias für access_entity_id, der zur Kompatibilität mit bestehenden Automatisierungen beibehalten wird."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Access control entity",
                     "description": "Optional schedule.* or input_boolean.* entity. Guest access is allowed only while it is on."
+                },
+                "schedule_entity_id": {
+                    "name": "Schedule entity (deprecated)",
+                    "description": "Deprecated alias for access_entity_id, kept for compatibility with existing automations."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/en.json
+++ b/custom_components/ha_guest_mode/translations/en.json
@@ -70,9 +70,9 @@
                     "name": "Dashboard",
                     "description": "The URL path of the desired dashboard (e.g., 'lovelace-guest'). Do not include the leading slash."
                 },
-                "schedule_entity_id": {
-                    "name": "Schedule entity",
-                    "description": "Optional schedule.* entity. If set, guest access is revoked when the schedule is not on."
+                "access_entity_id": {
+                    "name": "Access control entity",
+                    "description": "Optional schedule.* or input_boolean.* entity. Guest access is allowed only while it is on."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Dashboard (optional)"
             },
-            "schedule_entity": {
-                "name": "Schedule entity (optional)"
+            "access_entity": {
+                "name": "Access control entity"
             },
-            "schedule": {
-                "name": "Schedule"
-            },
-            "schedule_placeholder": {
-                "name": "Select a schedule (optional)"
+            "access_entity_placeholder": {
+                "name": "Select an access control entity (optional)"
             },
             "default_dashboard": {
                 "name": "Default Dashboard"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "The usage limit for this token has been reached."
             },
-            "schedule_not_active": {
-                "name": "Guest access is currently outside the allowed schedule."
+            "access_disabled": {
+                "name": "Guest access is currently disabled."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Entidad de control de acceso",
                     "description": "Entidad schedule.* o input_boolean.* opcional. El acceso de invitado solo se permite mientras esté activada."
+                },
+                "schedule_entity_id": {
+                    "name": "Entidad de horario (obsoleta)",
+                    "description": "Alias obsoleto de access_entity_id, conservado para mantener la compatibilidad con automatizaciones existentes."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/es.json
+++ b/custom_components/ha_guest_mode/translations/es.json
@@ -70,9 +70,9 @@
                     "name": "Tablero",
                     "description": "La ruta de la URL del tablero deseado (por ejemplo, 'lovelace-guest'). No incluya la barra inclinada inicial."
                 },
-                "schedule_entity_id": {
-                    "name": "Entidad de horario",
-                    "description": "Entidad schedule.* opcional. Si se define, el acceso de invitado se revoca cuando el horario no está activado."
+                "access_entity_id": {
+                    "name": "Entidad de control de acceso",
+                    "description": "Entidad schedule.* o input_boolean.* opcional. El acceso de invitado solo se permite mientras esté activada."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Tablero (opcional)"
             },
-            "schedule_entity": {
-                "name": "Entidad de horario (opcional)"
+            "access_entity": {
+                "name": "Entidad de control de acceso"
             },
-            "schedule": {
-                "name": "Horario"
-            },
-            "schedule_placeholder": {
-                "name": "Seleccionar un horario (opcional)"
+            "access_entity_placeholder": {
+                "name": "Seleccionar una entidad de control de acceso (opcional)"
             },
             "default_dashboard": {
                 "name": "Tablero predeterminado"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "Se ha alcanzado el límite de uso para este token."
             },
-            "schedule_not_active": {
-                "name": "El acceso de invitado está actualmente fuera del horario permitido."
+            "access_disabled": {
+                "name": "El acceso de invitado está desactivado actualmente."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Entité de contrôle d'accès",
                     "description": "Entité schedule.* ou input_boolean.* optionnelle. L'accès invité est autorisé uniquement lorsqu'elle est activée."
+                },
+                "schedule_entity_id": {
+                    "name": "Entité planning (obsolète)",
+                    "description": "Ancien nom de access_entity_id, conservé pour assurer la compatibilité avec les automatisations existantes."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/fr.json
+++ b/custom_components/ha_guest_mode/translations/fr.json
@@ -70,9 +70,9 @@
                     "name": "Tableau de bord",
                     "description": "Le chemin de l'URL du tableau de bord souhaité (par exemple, 'lovelace-guest'). N'incluez pas le slash au début."
                 },
-                "schedule_entity_id": {
-                    "name": "Entité planning",
-                    "description": "Entité schedule.* optionnelle. Si elle est définie, l'accès invité est révoqué lorsque le planning n'est pas activé."
+                "access_entity_id": {
+                    "name": "Entité de contrôle d'accès",
+                    "description": "Entité schedule.* ou input_boolean.* optionnelle. L'accès invité est autorisé uniquement lorsqu'elle est activée."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Tableau de bord (optionnel)"
             },
-            "schedule_entity": {
-                "name": "Entité planning (optionnelle)"
+            "access_entity": {
+                "name": "Entité de contrôle d'accès"
             },
-            "schedule": {
-                "name": "Planning"
-            },
-            "schedule_placeholder": {
-                "name": "Sélectionner un planning (optionnel)"
+            "access_entity_placeholder": {
+                "name": "Sélectionner une entité de contrôle d'accès (optionnel)"
             },
             "default_dashboard": {
                 "name": "Tableau de bord par défaut"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "La limite d'utilisation pour ce jeton a été atteinte."
             },
-            "schedule_not_active": {
-                "name": "L'accès invité est actuellement hors des plages horaires autorisées."
+            "access_disabled": {
+                "name": "L'accès invité est actuellement désactivé."
             }
         }   
     }

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -70,9 +70,9 @@
                     "name": "Cruscotto",
                     "description": "Il percorso URL del cruscotto desiderato (ad es. 'lovelace-guest'). Non includere la barra iniziale."
                 },
-                "schedule_entity_id": {
-                    "name": "Entità pianificazione",
-                    "description": "Entità schedule.* opzionale. Se impostata, l'accesso ospite viene revocato quando la pianificazione non è attiva."
+                "access_entity_id": {
+                    "name": "Entità di controllo accesso",
+                    "description": "Entità schedule.* o input_boolean.* opzionale. L'accesso ospite è consentito solo mentre è attiva."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Cruscotto (opzionale)"
             },
-            "schedule_entity": {
-                "name": "Entità pianificazione (opzionale)"
+            "access_entity": {
+                "name": "Entità di controllo accesso"
             },
-            "schedule": {
-                "name": "Pianificazione"
-            },
-            "schedule_placeholder": {
-                "name": "Seleziona una pianificazione (opzionale)"
+            "access_entity_placeholder": {
+                "name": "Seleziona un'entità di controllo accesso (opzionale)"
             },
             "default_dashboard": {
                 "name": "Cruscotto predefinito"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "Il limite di utilizzo per questo token è stato raggiunto."
             },
-            "schedule_not_active": {
-                "name": "L'accesso ospite è attualmente fuori dall'orario consentito."
+            "access_disabled": {
+                "name": "L'accesso ospite è attualmente disabilitato."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/it.json
+++ b/custom_components/ha_guest_mode/translations/it.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Entità di controllo accesso",
                     "description": "Entità schedule.* o input_boolean.* opzionale. L'accesso ospite è consentito solo mentre è attiva."
+                },
+                "schedule_entity_id": {
+                    "name": "Entità pianificazione (deprecata)",
+                    "description": "Alias deprecato di access_entity_id, mantenuto per la compatibilità con le automazioni esistenti."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -70,9 +70,9 @@
                     "name": "Dashboard",
                     "description": "Het URL-pad van het gewenste dashboard (bijv. 'lovelace-guest'). Voeg de voorloop-slash niet toe."
                 },
-                "schedule_entity_id": {
-                    "name": "Schema-entiteit",
-                    "description": "Optionele schedule.*-entiteit. Indien ingesteld, wordt gasttoegang ingetrokken wanneer het schema niet aan staat."
+                "access_entity_id": {
+                    "name": "Toegangsbeheerentiteit",
+                    "description": "Optionele schedule.*- of input_boolean.*-entiteit. Gasttoegang is alleen toegestaan zolang deze aan staat."
                 }
             }
         }
@@ -151,14 +151,11 @@
             "dashboard": {
                 "name": "Dashboard (optioneel)"
             },
-            "schedule_entity": {
-                "name": "Schema-entiteit (optioneel)"
+            "access_entity": {
+                "name": "Toegangsbeheerentiteit"
             },
-            "schedule": {
-                "name": "Schema"
-            },
-            "schedule_placeholder": {
-                "name": "Schema selecteren (optioneel)"
+            "access_entity_placeholder": {
+                "name": "Toegangsbeheerentiteit selecteren (optioneel)"
             },
             "default_dashboard": {
                 "name": "Standaard dashboard"
@@ -249,8 +246,8 @@
             "usage_limit_reached": {
                 "name": "De gebruikslimiet voor deze token is bereikt."
             },
-            "schedule_not_active": {
-                "name": "Gasttoegang valt momenteel buiten het toegestane schema."
+            "access_disabled": {
+                "name": "Gasttoegang is momenteel uitgeschakeld."
             }
         }
     }

--- a/custom_components/ha_guest_mode/translations/nl.json
+++ b/custom_components/ha_guest_mode/translations/nl.json
@@ -73,6 +73,10 @@
                 "access_entity_id": {
                     "name": "Toegangsbeheerentiteit",
                     "description": "Optionele schedule.*- of input_boolean.*-entiteit. Gasttoegang is alleen toegestaan zolang deze aan staat."
+                },
+                "schedule_entity_id": {
+                    "name": "Schema-entiteit (verouderd)",
+                    "description": "Verouderde alias voor access_entity_id, behouden voor compatibiliteit met bestaande automatiseringen."
                 }
             }
         }

--- a/custom_components/ha_guest_mode/utils.py
+++ b/custom_components/ha_guest_mode/utils.py
@@ -46,8 +46,8 @@ def parse_utc_datetime(value: str) -> datetime:
     return as_utc_datetime(parsed)
 
 
-def normalize_schedule_entity_id(value) -> str | None:
-    """Normalize and validate an optional schedule entity id."""
+def normalize_access_entity_id(value) -> str | None:
+    """Normalize and validate an optional access control entity id."""
     if value is None:
         return None
 
@@ -56,24 +56,43 @@ def normalize_schedule_entity_id(value) -> str | None:
         return None
 
     domain, separator, object_id = entity_id.partition(".")
-    if domain != "schedule" or not separator or not object_id:
-        raise ValueError("schedule_entity_id must be a schedule entity")
+    if domain not in {"schedule", "input_boolean"} or not separator or not object_id:
+        raise ValueError(
+            "access_entity_id must be a schedule or input_boolean entity"
+        )
 
     return entity_id
 
 
-def is_schedule_entity_active(hass: HomeAssistant, value) -> bool:
-    """Return true only when the configured schedule exists and is on."""
+def resolve_access_entity_id(access_value, legacy_schedule_value) -> str | None:
+    """Resolve the current and legacy access entity fields."""
+    access_entity_id = normalize_access_entity_id(access_value)
+    schedule_entity_id = normalize_access_entity_id(legacy_schedule_value)
+
+    if (
+        access_entity_id is not None
+        and schedule_entity_id is not None
+        and access_entity_id != schedule_entity_id
+    ):
+        raise ValueError(
+            "access_entity_id and schedule_entity_id must reference the same entity"
+        )
+
+    return access_entity_id or schedule_entity_id
+
+
+def is_access_entity_active(hass: HomeAssistant, value) -> bool:
+    """Return true only when the configured access entity exists and is on."""
     try:
-        schedule_entity_id = normalize_schedule_entity_id(value)
+        access_entity_id = normalize_access_entity_id(value)
     except ValueError:
         return False
 
-    if schedule_entity_id is None:
+    if access_entity_id is None:
         return True
 
-    schedule_state = hass.states.get(schedule_entity_id)
-    return schedule_state is not None and schedule_state.state == STATE_ON
+    access_state = hass.states.get(access_entity_id)
+    return access_state is not None and access_state.state == STATE_ON
 
 
 async def async_update_qr_code_entity(hass: HomeAssistant) -> None:

--- a/custom_components/ha_guest_mode/validateTokenView.py
+++ b/custom_components/ha_guest_mode/validateTokenView.py
@@ -11,7 +11,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers.translation import async_get_translations
 
 from .const import DATABASE, DOMAIN
-from .utils import async_sync_acm_dashboards, is_schedule_entity_active, parse_utc_datetime, utcnow, utcnow_isoformat
+from .utils import async_sync_acm_dashboards, is_access_entity_active, parse_utc_datetime, utcnow, utcnow_isoformat
 
 class ValidateTokenView(HomeAssistantView):
     name = "guest-mode:login"
@@ -25,11 +25,11 @@ class ValidateTokenView(HomeAssistantView):
         key = f"component.{DOMAIN}.entity.guest_error.{label}.name"
         return translations.get(key, f"Missing translation: {key}")
 
-    def _is_schedule_active(self, token_row: sqlite3.Row) -> bool:
+    def _is_access_enabled(self, token_row: sqlite3.Row) -> bool:
         if "schedule_entity_id" not in token_row.keys():
             return True
 
-        return is_schedule_entity_active(self.hass, token_row["schedule_entity_id"])
+        return is_access_entity_active(self.hass, token_row["schedule_entity_id"])
 
     async def _restore_managed_user(self, cursor, token_row: sqlite3.Row):
         available_groups = []
@@ -107,17 +107,19 @@ class ValidateTokenView(HomeAssistantView):
 
         
         if result is None:
+            conn.close()
             return web.Response(status=404, text=self.get_translations(translations, "token_not_found"))
 
-        if not self._is_schedule_active(result):
+        if not self._is_access_enabled(result):
             conn.close()
-            return web.Response(status=403, text=self.get_translations(translations, "schedule_not_active"))
+            return web.Response(status=403, text=self.get_translations(translations, "access_disabled"))
 
         try:
             first_used = result["first_used"]
             times_used = result["times_used"] or 0
             usage_limit = result["usage_limit"]
             if usage_limit is not None and usage_limit > 0 and times_used >= usage_limit:
+                conn.close()
                 return web.Response(status=403, text=self.get_translations(translations, "usage_limit_reached"))
             
             now_iso = utcnow_isoformat()
@@ -142,6 +144,7 @@ class ValidateTokenView(HomeAssistantView):
         try:
             public_key = self.hass.data.get("public_key")
             if public_key is None:
+                conn.close()
                 return web.Response(status=500, text=self.get_translations(translations, "internal_server_error"))
             decoded_token = jwt.decode(result["token_ha_guest_mode"], public_key, algorithms=["RS256"])
             is_never_expire = bool(result["is_never_expire"])
@@ -151,14 +154,18 @@ class ValidateTokenView(HomeAssistantView):
                 start_date = parse_utc_datetime(decoded_token.get("startDate"))
                 end_date = parse_utc_datetime(decoded_token.get("endDate"))
         except jwt.ExpiredSignatureError:
+            conn.close()
             return web.Response(status=401, text=self.get_translations(translations, "expired_token"))
         except jwt.InvalidTokenError:
+            conn.close()
             return web.Response(status=401, text=self.get_translations(translations, "invalid_token"))
         except Exception as e:
+            conn.close()
             return web.Response(status=400, text=str(e))
 
         now = utcnow()
         if not is_never_expire and (now < start_date or now > end_date):
+            conn.close()
             return web.Response(status=403, text=self.get_translations(translations, "not_yet_or_expired"))
         
         token = result["token_ha"]
@@ -186,6 +193,7 @@ class ValidateTokenView(HomeAssistantView):
                     users = await self.hass.auth.async_get_users()
 
             if user is None:
+                conn.close()
                 return web.Response(status=404, text=self.get_translations(translations, "user_not_found"))
             
             token_args = {
@@ -207,6 +215,7 @@ class ValidateTokenView(HomeAssistantView):
                     None,
                 )
                 if refresh_token is None:
+                    conn.close()
                     return web.Response(status=500, text=self.get_translations(translations, "internal_server_error"))
 
             token = self.hass.auth.async_create_access_token(refresh_token)

--- a/custom_components/ha_guest_mode/websocketCommands.py
+++ b/custom_components/ha_guest_mode/websocketCommands.py
@@ -15,8 +15,8 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers import config_validation as cv
 
 from .const import DATABASE
-from .schedule_access import async_refresh_schedule_listeners
-from .utils import async_sync_acm_dashboards, async_update_qr_code_entity, normalize_schedule_entity_id, parse_utc_datetime, utcnow
+from .access_control import async_refresh_access_listeners
+from .utils import async_sync_acm_dashboards, async_update_qr_code_entity, parse_utc_datetime, resolve_access_entity_id, utcnow
 
 
 async def _async_get_all_groups(hass: HomeAssistant):
@@ -57,7 +57,7 @@ async def list_users(
     cursor.execute('SELECT * FROM tokens')
     token_rows = cursor.fetchall()
     sync_acm_needed = False
-    schedule_listeners_needed = False
+    access_listeners_needed = False
 
     async def remove_managed_user_if_needed(user_id: str, managed: bool) -> None:
         nonlocal sync_acm_needed
@@ -93,7 +93,7 @@ async def list_users(
                             hass.auth.async_remove_refresh_token(refresh_token)
 
                 cursor.execute('DELETE FROM tokens WHERE id = ?', (token["id"],))
-                schedule_listeners_needed = True
+                access_listeners_needed = True
                 await remove_managed_user_if_needed(token["userId"], bool(token.get("managed_user")))
                 continue
 
@@ -189,6 +189,7 @@ async def list_users(
                     "last_used": token["last_used"],
                     "times_used": token["times_used"] or 0,
                     "usage_limit": token["usage_limit"],
+                    "access_entity_id": token.get("schedule_entity_id"),
                     "schedule_entity_id": token.get("schedule_entity_id"),
                 }
             )
@@ -208,8 +209,8 @@ async def list_users(
 
     conn.commit()
     conn.close()
-    if schedule_listeners_needed:
-        await async_refresh_schedule_listeners(hass)
+    if access_listeners_needed:
+        await async_refresh_access_listeners(hass)
     if sync_acm_needed:
         await async_sync_acm_dashboards(hass)
     connection.send_result(msg["id"], result)
@@ -247,6 +248,7 @@ async def list_groups(
         vol.Optional("new_user_name"): str,
         vol.Optional("group_ids"): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional("new_user_local_only", default=False): bool,
+        vol.Optional("access_entity_id"): vol.Any(str, None),
         vol.Optional("schedule_entity_id"): vol.Any(str, None),
     }
 )
@@ -269,7 +271,9 @@ async def create_token(
         managed_user_local_only = None
 
         try:
-            schedule_entity_id = normalize_schedule_entity_id(msg.get("schedule_entity_id"))
+            access_entity_id = resolve_access_entity_id(
+                msg.get("access_entity_id"), msg.get("schedule_entity_id")
+            )
         except ValueError as err:
             connection.send_message(
                 websocket_api.error_message(
@@ -400,13 +404,13 @@ async def create_token(
                 managed_user_name,
                 managed_user_groups,
                 managed_user_local_only,
-                schedule_entity_id,
+                access_entity_id,
             ),
         )
         conn.commit()
         conn.close()
 
-        await async_refresh_schedule_listeners(hass)
+        await async_refresh_access_listeners(hass)
 
         if managed_user:
             await async_sync_acm_dashboards(hass)
@@ -466,7 +470,7 @@ async def delete_token(
 
     conn.commit()
     conn.close()
-    await async_refresh_schedule_listeners(hass)
+    await async_refresh_access_listeners(hass)
     if sync_acm_needed:
         await async_sync_acm_dashboards(hass)
     connection.send_result(msg["id"], True)

--- a/custom_components/ha_guest_mode/www/ha-guest-mode.js
+++ b/custom_components/ha_guest_mode/www/ha-guest-mode.js
@@ -55,7 +55,7 @@ class GuestModePanel extends LitElement {
       urls: { type: Object },
       dashboards: { type: Array },
       dashboard: { type: String },
-      scheduleEntityId: { type: String },
+      accessEntityId: { type: String },
       copyLinkMode: { type: Boolean },
       defaultUser: { type: String },
       defaultDashboard: { type: String },
@@ -81,7 +81,7 @@ class GuestModePanel extends LitElement {
     this.urls = {};
     this.dashboards = [];
     this.dashboard = '';
-    this.scheduleEntityId = '';
+    this.accessEntityId = '';
     this.copyLinkMode = false;
     this.defaultUser = '';
     this.defaultDashboard = '';
@@ -291,7 +291,7 @@ class GuestModePanel extends LitElement {
               last_used: token.last_used ? new Date(token.last_used).toLocaleString(userLocale).replace(/:\d{2}$/, "") : this.translate("never"),
               times_used: token.times_used || 0,
               usage_limit: token.usage_limit,
-              schedule_entity_id: token.schedule_entity_id || '',
+              access_entity_id: token.access_entity_id || token.schedule_entity_id || '',
             });
           });
       });
@@ -385,9 +385,9 @@ class GuestModePanel extends LitElement {
     this.dashboard = value || "";
   }
 
-  scheduleChanged(e) {
+  accessEntityChanged(e) {
     const value = e.detail?.value;
-    this.scheduleEntityId = value || "";
+    this.accessEntityId = value || "";
   }
 
   groupSelected(e) {
@@ -437,8 +437,8 @@ class GuestModePanel extends LitElement {
       payload.dashboard = this.dashboard;
     }
 
-    if (this.scheduleEntityId) {
-      payload.schedule_entity_id = this.scheduleEntityId;
+    if (this.accessEntityId) {
+      payload.access_entity_id = this.accessEntityId;
     }
 
     if (!this.name) {
@@ -482,6 +482,7 @@ class GuestModePanel extends LitElement {
 
     this.hass.callWS(payload).then(() => {
       this.fetchUsers();
+      this.accessEntityId = '';
       this.isCreateDialogOpen = false;
       this.modalAlert = '';
     }).catch(err => {
@@ -829,10 +830,10 @@ class GuestModePanel extends LitElement {
               <ha-entity-picker
                 .hass=${this.hass}
                 .label=${""}
-                .placeholder=${this.translate("schedule_placeholder") || "Select a schedule (optional)"}
-                .value=${this.scheduleEntityId || ""}
-                .includeDomains=${["schedule"]}
-                @value-changed=${this.scheduleChanged}
+                .placeholder=${this.translate("access_entity_placeholder") || "Select an access control entity (optional)"}
+                .value=${this.accessEntityId || ""}
+                .includeDomains=${["schedule", "input_boolean"]}
+                @value-changed=${this.accessEntityChanged}
               ></ha-entity-picker>
               <ha-input
                 .label=${this.translate("usage_limit")}
@@ -1134,7 +1135,7 @@ class GuestModePanel extends LitElement {
                       `}
                       ${this.translate("used")}: ${token.isUsed ? this.translate("yes").toLowerCase() : this.translate("no").toLowerCase() } <br>
                       ${this.translate("dashboard")}: ${dashboardTitle} <br>
-                      ${token.schedule_entity_id ? html`${this.translate("schedule")}: ${token.schedule_entity_id} <br>` : ''}
+                      ${token.access_entity_id ? html`${this.translate("access_entity")}: ${token.access_entity_id} <br>` : ''}
                       ${this.translate("first_used")}: ${token.first_used} <br>
                       ${this.translate("last_used")}: ${token.last_used} <br>
                       ${this.translate("times_used")}: ${token.times_used}${token.usage_limit ? ` / ${token.usage_limit}` : ''} <br>


### PR DESCRIPTION
## Summary

- allow reusable guest links to be controlled by `input_boolean.*` or `schedule.*` entities
- revoke Guest Mode credentials when the configured entity is no longer `on`
- add `access_entity_id` across the UI and service while preserving `schedule_entity_id` compatibility
- update translations and documentation for recurring guest access

Closes #59.

## Testing

- `python3 -m compileall custom_components/ha_guest_mode`
- `node --check custom_components/ha_guest_mode/www/ha-guest-mode.js`
- Hassfest: 1 integration, 0 invalid integrations
- targeted access entity normalization, alias, and state checks
- translation key consistency across all 6 locales
- `git diff --check`

Full Home Assistant runtime tests were not run because the local Python environment does not include Home Assistant.